### PR TITLE
configure CI testing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,8 +14,11 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Gradle
-      run: ./code/gradlew build
+      working-directory: ./code
+      run: ./gradlew build
     - name: Unit Test
-      run: ./code/gradlew test
+      working-directory: ./code
+      run: ./gradlew test
     - name: UI Test
-      run: ./code/gradlew cAT
+      working-directory: ./code
+      run: ./gradlew cAT

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,3 +15,7 @@ jobs:
         java-version: 1.8
     - name: Build with Gradle
       run: ./code/gradlew build
+    - name: Unit Test
+      run: ./code/gradlew test
+    - name: UI Test
+      run: ./code/gradlew cAT

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.google.gms:google-services:4.3.2'
     }
 }

--- a/code/gradle/wrapper/gradle-wrapper.properties
+++ b/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 30 11:45:05 MDT 2019
+#Sun Oct 20 10:28:28 MDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
notes: 
- build is currently failing because we're missing the google-services.json. 
- before, the build was incorrectly passing due to the gradle script being run in the wrong directory :see_no_evil: 

#todo: #24
- generate a google-services.json (I'm guessing @jacobrec will do this step as a part of #4 while setting up user authentication
- base64 encode the json, make it a secret, and integrate it in the pipeline